### PR TITLE
use paths to library resources

### DIFF
--- a/.github/workflows/browsers.json
+++ b/.github/workflows/browsers.json
@@ -23,7 +23,12 @@
 			"capabilities": {
 				"alwaysMatch": {
 					"goog:chromeOptions": {
-						"args": ["--headless", "--disbale-gpu", "--disable-dev-shm-usage", "--start-maximized"]
+						"args": [
+							"--headless",
+							"--disbale-gpu",
+							"--disable-dev-shm-usage",
+							"--start-maximized"
+						]
 					}
 				}
 			}
@@ -36,7 +41,12 @@
 			"capabilities": {
 				"alwaysMatch": {
 					"ms:edgeOptions": {
-						"args": ["--headless", "--disbale-gpu", "--disable-dev-shm-usage", "--start-maximized"]
+						"args": [
+							"--headless",
+							"--disbale-gpu",
+							"--disable-dev-shm-usage",
+							"--start-maximized"
+						]
 					}
 				}
 			}

--- a/.github/workflows/browsers.json
+++ b/.github/workflows/browsers.json
@@ -23,7 +23,7 @@
 			"capabilities": {
 				"alwaysMatch": {
 					"goog:chromeOptions": {
-						"args": ["--headless", "--disbale-gpu", "--disable-dev-shm-usage"]
+						"args": ["--headless", "--disbale-gpu", "--disable-dev-shm-usage", "--start-maximized"]
 					}
 				}
 			}
@@ -36,7 +36,7 @@
 			"capabilities": {
 				"alwaysMatch": {
 					"ms:edgeOptions": {
-						"args": ["--headless", "--disbale-gpu", "--disable-dev-shm-usage"]
+						"args": ["--headless", "--disbale-gpu", "--disable-dev-shm-usage", "--start-maximized"]
 					}
 				}
 			}

--- a/nodejs/src/results.ts
+++ b/nodejs/src/results.ts
@@ -97,6 +97,8 @@ ${result.completedCollections} collections`);
 		output.push(`[run_error] ${errorAction.error}`);
 	}
 
+	if (result.errorLogs.length) output.push("");
+
 	return false;
 }
 
@@ -109,7 +111,7 @@ function logCollectionResult(
 	let { loggerAction } = collection;
 	if ("start_collection" !== loggerAction.type) return true;
 
-	output.push(`${SPACE}${loggerAction.collection_url}`);
+	output.push(`${loggerAction.collection_url}`);
 
 	// when everything in the collection goes right
 	if (
@@ -119,8 +121,8 @@ function logCollectionResult(
 		collection.expectedModules === collection.completedModules
 	) {
 		output.push(
-			`${collection.expectedTests} tests
-${loggerAction.expected_module_count} modules`,
+			`${SPACE}${collection.expectedTests} tests
+${SPACE}${loggerAction.expected_module_count} modules`,
 		);
 
 		return true;
@@ -128,8 +130,9 @@ ${loggerAction.expected_module_count} modules`,
 
 	for (let errorAction of collection.errorLogs) {
 		if ("collection_error" !== errorAction.type) continue;
-		output.push(`[collection_error] ${errorAction.error}`);
+		output.push(`${SPACE}[collection_error] ${errorAction.error}`);
 	}
+	if (collection.errorLogs.length) output.push("");
 
 	return false;
 }
@@ -157,8 +160,10 @@ function logModuleResult(
 
 	for (let errorAction of module.errorLogs) {
 		if ("collection_error" !== errorAction.type) continue;
-		output.push(`${SPACE}[module_error] ${errorAction.error}`);
+		output.push(`${SPACE.repeat(2)}[module_error] ${errorAction.error}`);
 	}
+
+	if (module.errorLogs.length) output.push("");
 
 	return false;
 }

--- a/webdriver/src/results.ts
+++ b/webdriver/src/results.ts
@@ -7,7 +7,6 @@ export interface TestResults {
 	loggerEndAction: LoggerAction | undefined;
 }
 
-// remove logger actions
 export interface ModuleResults {
 	loggerAction: LoggerAction;
 	fails: number;
@@ -47,8 +46,6 @@ export interface RunResults {
 	collections: (CollectionResults | undefined)[];
 }
 
-// track if session started or not
-// if browser never launched
 export interface SessionResults {
 	fails: number;
 	errors: number;
@@ -57,12 +54,14 @@ export interface SessionResults {
 
 const SPACE = "  ";
 
+/*
+	Lots of nested loops because results a nested structure.
+	I'd rather see composition nested in one function
+	than have for loops spread across each function.
+*/
+
 export function getResultsAsString(sessionResults: SessionResults): string {
 	const output: string[] = [];
-
-	// Lots of nested loops because results a nested structure.
-	// I'd rather see composition nested in one function
-	// than have for loops spread across each function.
 
 	logSessionErrors(output, sessionResults);
 

--- a/webdriver/src/routes.ts
+++ b/webdriver/src/routes.ts
@@ -8,13 +8,7 @@ import { testHanger } from "./test_hangar.js";
 import { ConfigInterface } from "./config.js";
 
 let cwd = process.cwd();
-
-// better done with URL? feels weird
-let corePath = path.join(import.meta.url.substring(5), "../../../core/dist/");
-let browserPath = path.join(
-	import.meta.url.substring(5),
-	"../../../browser/dist/",
-);
+const parentPath = path.join(import.meta.url.substring(5), "../../../");
 
 const MIME_TYPES: Record<string, string> = {
 	octet: "application/octet-stream",
@@ -138,35 +132,33 @@ function logAction(
 async function serveFile(req: IncomingMessage, res: ServerResponse) {
 	let { url, method } = req;
 
-	if (!url) {
+	if (!url || "GET" !== method) {
 		res.setHeader("Content-Type", MIME_TYPES["html"]);
 		res.writeHead(400);
 		res.end();
 		return;
 	}
 
-	let ext = "";
-	if (url.endsWith("/")) ext = "index.html";
+	// assume http 1.1
+	let urlFilePath = path.join(url);
+
+	let extStr = "";
+	if (url.endsWith("/")) extStr = "index.html";
 	let urlNoPrefix = url;
-	if (url.startsWith("/jackrabbit")) urlNoPrefix = url.substring(11);
-	let filePath = path.join(cwd, urlNoPrefix, ext);
 
-	let stream: fs.ReadStream | undefined;
-	if (url.startsWith("/jackrabbit/core/") && "GET" === method) {
-		stream = await getDirectoryScopedFile(filePath, corePath);
-	}
-	if (url.startsWith("/jackrabbit/browser/") && "GET" === method) {
-		stream = await getDirectoryScopedFile(filePath, browserPath);
+	if (urlFilePath.startsWith("/jackrabbit")) {
+		let strippedUrl = urlFilePath.substring("/jackrabbit".length);
+		urlFilePath = path.join(parentPath, strippedUrl, extStr);
+	} else {
+		urlFilePath = path.join(cwd, urlNoPrefix, extStr);
 	}
 
-	if (!url.startsWith("/jackrabbit") && "GET" === method) {
-		stream = await getDirectoryScopedFile(filePath, cwd);
-	}
+	let stream = await getFile(urlFilePath);
 
 	if (stream) {
 		// throws errors if not a string
 		// filepath is always a string
-		const ext = path.extname(filePath).substring(1).toLowerCase();
+		const ext = path.extname(urlFilePath).substring(1).toLowerCase();
 		let mimeType = MIME_TYPES[ext] ?? MIME_TYPES["octet"];
 		res.setHeader("Content-Type", mimeType);
 		res.writeHead(200);
@@ -198,12 +190,7 @@ function getLoggerActionFromRequestBody(
 	});
 }
 
-async function getDirectoryScopedFile(
-	filePath: string,
-	basePath: string,
-): Promise<fs.ReadStream | undefined> {
-	if (!filePath.startsWith(basePath)) return;
-
+async function getFile(filePath: string): Promise<fs.ReadStream | undefined> {
 	try {
 		await fs.promises.access(filePath);
 		return fs.createReadStream(filePath);

--- a/webdriver/src/webdriver.ts
+++ b/webdriver/src/webdriver.ts
@@ -196,14 +196,14 @@ function setupProcess(
 			}
 		},
 	);
-	process.addListener("error", (error) => {
+	process.addListener("error", function (error) {
 		eventbus.dispatchAction({
 			id: jrId,
 			type: "session_error",
 			error: error.toString(),
 		});
 	});
-	process.addListener("exit", (statusCode) => {
+	process.addListener("exit", function (statusCode) {
 		if (statusCode) {
 			eventbus.dispatchAction({
 				type: "session_error",


### PR DESCRIPTION
Jackrabbit paths are now relative to the module location not the CWD.

This should prevent missing library files during test runs with downstream libraries.